### PR TITLE
Fix bug whereby clubhouse response body is nil but the content type

### DIFF
--- a/lib/clubhouse/client.rb
+++ b/lib/clubhouse/client.rb
@@ -72,6 +72,8 @@ module Clubhouse
       response = http.request(request)
 
       if [200,201,204].include?(response.code.to_i)
+        # Clubhouse API returns content type as application/json for DELETE request with no body :(
+        return {} if response.body.nil?
         JSON.parse(response.body)
       else
         raise_error_to_user(response)

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -51,10 +51,21 @@ module Clubhouse
     describe '#delete' do
       let(:uri) { URI.parse(subject.basepath + "/labels/1?token=toke%261234") }
       let(:req) { Net::HTTP::Delete.new(uri) }
+      let(:response) { Net::HTTPResponse.new('delete', '200', '') }
 
       it 'builds and makes request' do
         expect(Net::HTTP::Delete).to receive(:new).with(uri).and_return(req)
         expect(subject).to receive(:do_request).with(req).once
+
+        subject.delete('labels/1')
+      end
+
+      it 'successfully returns when response body is nil' do
+        # The delete request for clubhouse has no body which previously broke JSON.parse
+        allow(response).to receive(:body).and_return(nil)
+
+        expect(Net::HTTP::Delete).to receive(:new).with(uri).and_return(req)
+        expect_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
 
         subject.delete('labels/1')
       end


### PR DESCRIPTION
is still returned as application/json which breaks JSON.parse
